### PR TITLE
Invalid Domain (rogue <br>) in SNAFU.txt

### DIFF
--- a/SNAFU.txt
+++ b/SNAFU.txt
@@ -39514,7 +39514,7 @@ locationdata.predic.io
 marketing.predic.io
 ns1.predic.io
 partners.predic.io
-partners.predic.io<BR>www.partners.predic.io
+www.partners.predic.io
 sdk.predic.io
 tr0005.predic.io
 trkr.predic.io


### PR DESCRIPTION
Invalid domain
#391517 - partners.predic.io<br>www.partners.predic.io
#391517 + www.partners.predic.io